### PR TITLE
Fix mobile navbar button

### DIFF
--- a/styles/Navbar.module.css
+++ b/styles/Navbar.module.css
@@ -100,6 +100,7 @@ button.discord:hover {
     flex-direction: row-reverse;
     align-items: center;
     justify-content: right;
+    height: 48px;
   }
 
   .navbar > ul {


### PR DESCRIPTION
On the mobile friendly navbar expand menu, the button to expand only worked if you clicked one of the rectangles on the button. This commit fixes that issue and allows clicking anywhere in this blue area: 
<img width="93" alt="Screen Shot 2022-10-20 at 11 28 38 PM" src="https://user-images.githubusercontent.com/31748545/197127935-e80fc772-3b43-4b5c-ada3-1f1e8bd99439.png">

## Explanation of bug
Basically, the navbar expand menu uses a hidden checkbox element, but the clickable label element immediately below it had a height of 100%, or 0, because the navbar doesn't have a height - it's just expanded based on the minimum height needed to fit the elements inside it. As far as I can tell, the mobile navbar always has a height of 48px due to how the menu expand button works, so I've hard coded this in unless anyone has other opinions about this