### PR TITLE
Fix typo in about section

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -96,7 +96,7 @@ export default function Home() {
               </div>
               <h2>Levels</h2>
               <p>
-                LA CTF is open to all skill levels! No matter yhour experience,
+                LA CTF is open to all skill levels! No matter your experience,
                 there will be challenges just right for you!
               </p>
             </div>


### PR DESCRIPTION
I copy-pasted from figma and figma had a typo - this fixes that typo (and I fixed the typo in figma).