### PR TITLE
Add discord invite redirect at /discord page

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -16,9 +16,7 @@ function Navbar() {
       <ul>
         <li>
           <button
-            onClick={() =>
-              (window.location.href = "/discord")
-            }
+            onClick={() => (window.location.href = "/discord")}
             className={styles.discord}
           >
             <a href="/discord">Join Us</a>

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -17,11 +17,11 @@ function Navbar() {
         <li>
           <button
             onClick={() =>
-              (window.location.href = "https://discord.gg/qD6vmsgECn")
+              (window.location.href = "/discord")
             }
             className={styles.discord}
           >
-            <a href="https://discord.gg/qD6vmsgECn">Join Us</a>
+            <a href="/discord">Join Us</a>
           </button>
         </li>
         <li>

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,15 @@ const nextConfig = {
     path: "",
   },
   assetPrefix: !debug ? "https://lactf.uclaacm.com" : "",
+  async redirects() {
+    return [
+      {
+        source: '/discord',
+        destination: 'https://discord.gg/uZM6vxqHDq',
+        permanent: false,
+      },
+    ]
+  },
 };
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -11,11 +11,11 @@ const nextConfig = {
   async redirects() {
     return [
       {
-        source: '/discord',
-        destination: 'https://discord.gg/uZM6vxqHDq',
+        source: "/discord",
+        destination: "https://discord.gg/uZM6vxqHDq",
         permanent: false,
       },
-    ]
+    ];
   },
 };
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -196,10 +196,10 @@ export default function Home() {
                     alt="Discord logo."
                   />
                   <a
-                    href="https://discord.gg/VEJf6gqdP5"
+                    href="/discord"
                     className={`${styles.contactsLink} ${styles.discord}`}
                   >
-                    discord.gg/VEJf6gqdP5
+                    lactf.uclaacm.com/discord
                   </a>
                 </li>
                 <li>


### PR DESCRIPTION
Self-explanatory, create a redirect at /discord to have a memorable link to the discord and consolidate the multiple discord invites currently used on the page