### PR TITLE
Fix starting time on website

### DIFF
--- a/components/Countdown.js
+++ b/components/Countdown.js
@@ -5,8 +5,8 @@ import styles from "../styles/Countdown.module.css";
 const Countdown = () => {
   let [time, setTime] = useState(0);
 
-  // Tentatively February 8 - 9 (below is 02/08/2025 6:00PM PST)
-  const endOfCountdowntime = 1739066400; // Unix timestamp of the date the timer counts down to
+  // below is 02/07/2025 8:00PM PST
+  const endOfCountdowntime = 1738987200; // Unix timestamp of the date the timer counts down to
 
   let updateTime = () =>
     setTime(Math.max(endOfCountdowntime - Date.now() / 1000, 0));

--- a/pages/index.js
+++ b/pages/index.js
@@ -88,8 +88,7 @@ export default function Home() {
               />
             </div>
             <p className={styles.subheading}>
-              Tentatively: <br />
-              Feb 8, 2025 - Feb 9, 2025
+              Feb 7, 2025 08:00PM PST - Feb 9, 2025 02:00PM PST
               <br />
               Covel Grand Horizons
             </p>


### PR DESCRIPTION
Before, the website said said tentatively 2/8-2/9 and timer counted down to 2/8 6pm.

This PR changes it to say 2/7 8:00PM to 2/9 2:00PM and adjusted the timer to count down to the correct time.
