### PR TITLE
Remove zoom and schedule buttons

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -114,26 +114,6 @@ export default function Home() {
                   CTFtime
                 </button>
               </a>
-              <a href="https://zoom.lac.tf">
-                <button
-                  className={
-                    styles.bigFatPinkButtonThatSaysRegisterUnderTheTimersOrSmth
-                  }
-                >
-                  Zoom
-                </button>
-              </a>
-            </div>
-            <div className={styles.heroButtonContainer}>
-              <a href="https://static.lac.tf/schedule.pdf">
-                <button
-                  className={
-                    styles.bigFatPinkButtonThatSaysRegisterUnderTheTimersOrSmth
-                  }
-                >
-                  Schedule
-                </button>
-              </a>
             </div>
           </div>
         </section>


### PR DESCRIPTION
Remove the Zoom and Schedule buttons from the homepage because they're both holdovers from 2024
